### PR TITLE
ISSUE 7: Detects dupe keys on arrays of hashes #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ YamlLint gem CHANGELOG
 ======================
 This file is used to list changes made in each version of the YamlLint gem.
 
+v0.0.6 (2015--??-??)
+-------------------
+- **[ISSUE #7](https://github.com/shortdudey123/yamllint/issues/7)** - Detects dupe keys on arrays of hashes (**Proper fix**)
+
 v0.0.5 (2015-05-05)
 -------------------
 - **[ISSUE #7](https://github.com/shortdudey123/yamllint/issues/7)** - Detects dupe keys on arrays of hashes

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -141,10 +141,8 @@ module YamlLint
 
       # Get the data and send it off for duplicate key validation
       def parse(psych_parse_data)
-        data_start = psych_parse_data.handler.root.children[0].children[0]
-        hash_start('')
+        data_start = psych_parse_data.handler.root.children[0]
         parse_recurse(data_start)
-        hash_end('')
       end
 
       private


### PR DESCRIPTION
The last fix for this did fix the underlying issue.  If the root structure was an array, it would strip off the array and iterate through the items assuming it was a hash.
