### PR TITLE
Update RSpec raise_error to be more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 
 Unreleased
 -------------------
+- **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific
 
 v0.0.8 (2016-07-10)
 -------------------

--- a/spec/linter_spec.rb
+++ b/spec/linter_spec.rb
@@ -9,7 +9,9 @@ describe 'YamlLint::Linter' do
   end
 
   it 'should throw an exception if given a bogus path' do
-    expect { linter.check('/does/not/exist') }.to raise_error
+    expect { linter.check('/does/not/exist') }.to raise_error(
+      YamlLint::FileNotFoundError
+    )
   end
 
   it 'should be happy with a valid YAML file' do


### PR DESCRIPTION
Fixes the following warning

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<YamlLint::FileNotFoundError: /does/not/exist: no such file>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/username/github/yamllint/spec/linter_spec.rb:12:in `block (2 levels) in <top (required)>'.
```
