### PR TITLE
Fix bug with files_to_exclude puts in Rake Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 Unreleased
 -------------------
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific
+- **[PR #25](https://github.com/shortdudey123/yamllint/pull/25)** - Fix bug with files_to_exclude puts in Rake Task
 
 v0.0.8 (2016-07-10)
 -------------------

--- a/lib/yamllint/rake_task.rb
+++ b/lib/yamllint/rake_task.rb
@@ -22,6 +22,7 @@ module YamlLint
       @disable_ext_check = false
       @extensions = nil
       @debug = false
+      @exclude_paths = []
 
       yield self if block_given?
 


### PR DESCRIPTION
Rake Task was outputing that it was excluding 1 file even though no exclude_paths was being passed.  This was due to it being nil, then flattened which gives `[nil]`.  This is an array with 1 element, so it was counting the `nil` as the 1 file that was excluded.
