### PR TITLE
Retrieve aliases not for keys

### DIFF
--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -151,29 +151,29 @@ module YamlLint
       def parse_recurse(psych_parse_data, is_sequence = false)
         is_key = false
         psych_parse_data.children.each do |n|
-          case n.class.to_s
-          when 'Psych::Nodes::Scalar'
+          case n
+          when Psych::Nodes::Scalar
             is_key = !is_key unless is_sequence
             @last_key.push(n.value) if is_key
             add_value(n.value, @last_key.last) unless is_key
             msg = "Scalar: #{n.value}, key: #{is_key}, last_key: #{@last_key}"
             YamlLint.logger.debug { msg }
             @last_key.pop if !is_key && !is_sequence
-          when 'Psych::Nodes::Sequence'
+          when Psych::Nodes::Sequence
             YamlLint.logger.debug { "Sequence: #{n.children}" }
             array_start(@last_key.last)
             parse_recurse(n, true)
             array_end(@last_key.last)
             is_key = false
             @last_key.pop
-          when 'Psych::Nodes::Mapping'
+          when Psych::Nodes::Mapping
             YamlLint.logger.debug { "Mapping: #{n.children}" }
             hash_start(@last_key.last)
             parse_recurse(n)
             hash_end(@last_key.last)
             is_key = false
             @last_key.pop
-          when 'Psych::Nodes::Alias'
+          when Psych::Nodes::Alias
             is_key = false
           end
         end

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -173,6 +173,8 @@ module YamlLint
             hash_end(@last_key.last)
             is_key = false
             @last_key.pop
+          when 'Psych::Nodes::Alias'
+            is_key = false
           end
         end
       end

--- a/spec/data/alias_dup_keys.yaml
+++ b/spec/data/alias_dup_keys.yaml
@@ -1,0 +1,6 @@
+---
+foo: &foo
+bar:
+  <<: *foo
+  key: val
+  key: val

--- a/spec/data/alias_dup_values.yaml
+++ b/spec/data/alias_dup_values.yaml
@@ -1,0 +1,7 @@
+---
+foo: &foo
+bar:
+  <<: *foo
+  key1: val
+  key2: val
+  key3: val

--- a/spec/linter_spec.rb
+++ b/spec/linter_spec.rb
@@ -70,4 +70,12 @@ describe 'YamlLint::Linter' do
   it 'should be unhapy with a YAML file full of spaces' do
     expect(linter.check(spec_data('spaces.yaml'))).to be(false)
   end
+
+  it 'shoud be happy with a YAML file with duplicated values under an alias' do
+    expect(linter.check(spec_data('alias_dup_values.yaml'))).to be(true)
+  end
+
+  it 'shoud be unhappy with a YAML file with duplicated keys under an alias' do
+    expect(linter.check(spec_data('alias_dup_keys.yaml'))).to be(false)
+  end
 end


### PR DESCRIPTION
Correct the detecting wrong key in such following YAML and test:
```bash
$ cat alias_dup_values.yaml
---
foo: &foo
bar:
  <<: *foo
  key1: val
  key2: val
  key3: val
$ yamllint alias_dup_values.yaml
Checking 1 files
alias_dup_values.yaml
  The same key is defined more than once: bar.val
YAML lint found 1 errors
```
And refactor to reduce codes