### PR TITLE
Update trollop to optimist to remove deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 - **[PR #28](https://github.com/shortdudey123/yamllint/pull/28)** - Fix Security/YAMLLoad rubocop offense
 - **[PR #29](https://github.com/shortdudey123/yamllint/pull/29)** - Update TraviCI Rubies
 - **[PR #30](https://github.com/shortdudey123/yamllint/pull/30)** - Fix Style/PercentLiteralDelimiters offense
+- **[PR #37](https://github.com/shortdudey123/yamllint/pull/37)** - Update trollop to optimist to remove deprecation warnings
 
 ## v0.0.9 (2016-09-16)
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific

--- a/lib/yamllint/cli.rb
+++ b/lib/yamllint/cli.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'trollop'
+require 'optimist'
 
 module YamlLint
   ###
@@ -76,7 +76,7 @@ module YamlLint
     end
 
     def setup_options
-      Trollop::Parser.new do
+      Optimist::Parser.new do
         banner 'Usage: yamllint [options] file1.yaml [file2.yaml ...]'
         version(YamlLint::VERSION)
 
@@ -92,7 +92,7 @@ module YamlLint
     def parse_options
       p = setup_options
 
-      @opts = Trollop.with_standard_exception_handling p do
+      @opts = Optimist.with_standard_exception_handling p do
         p.parse(@argv)
       end
 

--- a/yamllint.gemspec
+++ b/yamllint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'trollop', '~> 2'
+  spec.add_dependency 'optimist'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Hi,

I noticed that a new deprecation warning appeared in our logs, upon further inspection it is caused by the gem `trollop` being deprecated in favor of `optimist.`

`[DEPRECATION] This gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.`

ManageIQ/optimist@7a5e93f

Let me know is there is something else I should do.