### PR TITLE
Use github action to release on rubygems.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  create:
+    tags:
+      - v*
+
+jobs:
+        
+  build:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Publish packages
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}


### PR DESCRIPTION
Hi @shortdudey123,

Your `gem` is awesome. 

Thanks for it.

I can't wait to have the future release deployed on https://rubygems.org.

Here is a proposal to enable automatic deploy when any tag (started with `v`, like `v0.10.0`) with github action.

However, it requires **YOU** to add a _secret_ called `RUBYGEMS_AUTH_TOKEN` obtained from https://rubygems.org/profile/edit

Regards,