### PR TITLE
Check syntax with unsafe_load / load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 - **[PR #30](https://github.com/shortdudey123/yamllint/pull/30)** - Fix Style/PercentLiteralDelimiters offense
 - **[PR #37](https://github.com/shortdudey123/yamllint/pull/37)** - Update trollop to optimist to remove deprecation warnings
 - **[PR #42](https://github.com/shortdudey123/yamllint/pull/42)** - Allow empty YAML files
+- **[PR #44](https://github.com/shortdudey123/yamllint/pull/44)** - Check syntax with unsafe_load / load
 
 ## v0.0.9 (2016-09-16)
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -104,11 +104,13 @@ module YamlLint
     def check_syntax_valid?(yaml_data, errors_array)
       # For rationale behind the use of unsafe_load, and discussion, see:
       # https://github.com/shortdudey123/yamllint/issues/43
+      # rubocop:disable Security/YAMLLoad
       if YAML.respond_to?(:unsafe_load)
         YAML.unsafe_load(yaml_data)
       else
         YAML.load(yaml_data)
       end
+      # rubocop:enable Security/YAMLLoad
       true
     rescue YAML::SyntaxError => e
       errors_array << e.message

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -102,7 +102,13 @@ module YamlLint
 
     # Check that the data is valid YAML
     def check_syntax_valid?(yaml_data, errors_array)
-      YAML.safe_load(yaml_data)
+      # For rationale behind the use of unsafe_load, and discussion, see:
+      # https://github.com/shortdudey123/yamllint/issues/43
+      if YAML.respond_to?(:unsafe_load)
+        YAML.unsafe_load(yaml_data)
+      else
+        YAML.load(yaml_data)
+      end
       true
     rescue YAML::SyntaxError => e
       errors_array << e.message


### PR DESCRIPTION
As we discussed in #43, this changes `check_syntax_valid?` to attempt to process YAML data with `unsafe_load` if it is available, or `load` otherwise.

Unlike `safe_load`, these methods permit processing of valid YAML data that can be problematic if controlled by an adversary. But I argue that yamllint, designed to check files on disk, is processing a type of source code already anyway, so there is already an assumption that no adversary is writing to those files.

The technique of using `unsafe_load` and falling back to `load` is compatible across Ruby's behavior change in version 3.1, and is borrowed from Rails' approach to this same issue.