### PR TITLE
Rescue Psych exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 - **[PR #37](https://github.com/shortdudey123/yamllint/pull/37)** - Update trollop to optimist to remove deprecation warnings
 - **[PR #42](https://github.com/shortdudey123/yamllint/pull/42)** - Allow empty YAML files
 - **[PR #44](https://github.com/shortdudey123/yamllint/pull/44)** - Check syntax with unsafe_load / load
+- **[PR #45](https://github.com/shortdudey123/yamllint/pull/44)** - Rescue Psych exceptions
 
 ## v0.0.9 (2016-09-16)
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -112,7 +112,7 @@ module YamlLint
       end
       # rubocop:enable Security/YAMLLoad
       true
-    rescue YAML::SyntaxError => e
+    rescue YAML::SyntaxError, Psych::Exception => e
       errors_array << e.message
       false
     end


### PR DESCRIPTION
`Psych` is Ruby's default YAML parser since 1.9.3. It defines two exception classes that are subclasses of `Psych::Exception`. As we discussed in #43, rescuing them as well as `YAML::SyntaxError` provides a more-robust way to check YAML validity.

For example, without this PR, when yamllint's test suite includes an alias, rather than returning false, `check_syntax_valid?` raises an exception:

```
$ bundle exec rake yamllint
Running YamlLint...
Checking 8 files
Excluding 0 files
rake aborted!
Psych::BadAlias: Unknown alias: my_default
/home/jamie/p/yamllint/lib/yamllint/linter.rb:105:in `check_syntax_valid?'
```

This branch is built on top of #44 because they modify the same method and they're less likely to cause merge conflicts this way. If you choose to merge them, feel free to merge #44 first and then this, or simply close #44 and merge only this. The result should be the same either way.