### PR TITLE
Add 3 valid test files that require non-safe_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This file is used to list changes made in each version of the YamlLint gem.
 - **[PR #37](https://github.com/shortdudey123/yamllint/pull/37)** - Update trollop to optimist to remove deprecation warnings
 - **[PR #42](https://github.com/shortdudey123/yamllint/pull/42)** - Allow empty YAML files
 - **[PR #44](https://github.com/shortdudey123/yamllint/pull/44)** - Check syntax with unsafe_load / load
-- **[PR #45](https://github.com/shortdudey123/yamllint/pull/44)** - Rescue Psych exceptions
+- **[PR #45](https://github.com/shortdudey123/yamllint/pull/45)** - Rescue Psych exceptions
+- **[PR #46](https://github.com/shortdudey123/yamllint/pull/46)** - Add three valid test files
 
 ## v0.0.9 (2016-09-16)
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific

--- a/spec/data/valid_aliases.yaml
+++ b/spec/data/valid_aliases.yaml
@@ -1,0 +1,19 @@
+default: &my_default
+  foo: 1
+
+one_alternate:
+  <<: *my_default
+
+other_alternate:
+  <<: *my_default
+  foo: 2
+  bar: 3
+
+psych_example:
+  -
+    &F fareref: DOGMA
+    &C currency: GBP
+    &D departure: LAX
+    &A arrival: EDI
+  - { *F: MADF, *C: AUD, *D: SYD, *A: MEL }
+  - { *F: DFSF, *C: USD, *D: JFK, *A: MCO }

--- a/spec/data/valid_nonstandard_classes.yaml
+++ b/spec/data/valid_nonstandard_classes.yaml
@@ -1,0 +1,11 @@
+range: !ruby/range a..z
+regex: !ruby/regexp "/Marty McFly/i"
+compl: !ruby/object:Complex 3+4i
+timestamp: 2002-05-23T11:25:26.1Z
+colors:
+  - :red
+  - :green
+  - :blue
+  - :cyan
+  - :magenta
+  - :yellow

--- a/spec/data/valid_recursion.yaml
+++ b/spec/data/valid_recursion.yaml
@@ -1,0 +1,7 @@
+some_list: &001
+  - *001
+  - *001
+
+some_key: &some_anchor
+  sub_key1: value1
+  sub_key2: *some_anchor


### PR DESCRIPTION
As we discussed in #43, this adds some test files of valid yaml data that are correctly processed with `load`, or in ruby 3.1 `unsafe_load`. (I checked this by cherry-picking 1231a1e17aab2bd58f013d9dae95ea28a4883126.)

But in this branch, without that code, they fail with `safe_load`.