### PR TITLE
Fix README table typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 - **[PR #44](https://github.com/shortdudey123/yamllint/pull/44)** - Check syntax with unsafe_load / load
 - **[PR #45](https://github.com/shortdudey123/yamllint/pull/45)** - Rescue Psych exceptions
 - **[PR #46](https://github.com/shortdudey123/yamllint/pull/46)** - Add three valid test files
+- **[PR #47](https://github.com/shortdudey123/yamllint/pull/47)** - Fix readme typo
 
 ## v0.0.9 (2016-09-16)
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ $
 Add these options similarly to the path option seen above.
 
 | Option | Description | Default |
-| ------------- | ------------- | ------------- | ------------- |
+| ------------- | ------------- | ------------- |
 | `debug` | Debug logging | `false` |
 | `disable_ext_check` | Disable file extension check | `false` |
 | `exclude_paths` | List of files or paths to exclude from linting | `nil` |
-| `extensions` | Add more allowed extensions (list)| `nil` |
+| `extensions` | Add more allowed extensions (list) | `nil` |
 | `fail_on_error` | Continue on to the next rake task and don't fail even if YamlLint finds errors | `true` |
 | `paths` | List of files or paths to lint | `nil` |
 


### PR DESCRIPTION
An extra `------` in the second README table was preventing GitHub from rendering it correctly:

https://github.com/shortdudey123/yamllint/blob/6e80e8e295abed89478d089a7f42ad876eecb284/README.md#rake-task-options

vs.

https://github.com/jamiemccarthy/yamllint/blob/6ad6cd18d9e1b4258eb6d78159b68ca1c2f609c4/README.md#rake-task-options