### PR TITLE
Fix rubocop issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,17 +2,24 @@ AllCops:
   DisplayCopNames: true
 
 Metrics/AbcSize:
-  Max: 36
+  Max: 37
 
 Metrics/BlockLength:
   Exclude:
     - spec/*.rb
 
 Metrics/CyclomaticComplexity:
-  Max: 9
+  Max: 11
 
 Metrics/MethodLength:
-  Max: 26
+  Max: 27
+
+Metrics/ParameterLists:
+  Max: 5
+  MaxOptionalParameters: 4
+
+Metrics/PerceivedComplexity:
+  Max: 9
 
 Style/FrozenStringLiteralComment:
   Include:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   Max: 26
+
+Style/FrozenStringLiteralComment:
+  Include:
+    - lib/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the YamlLint gem.
 - **[PR #45](https://github.com/shortdudey123/yamllint/pull/45)** - Rescue Psych exceptions
 - **[PR #46](https://github.com/shortdudey123/yamllint/pull/46)** - Add three valid test files
 - **[PR #47](https://github.com/shortdudey123/yamllint/pull/47)** - Fix readme typo
+- **[PR #48](https://github.com/shortdudey123/yamllint/pull/48)** - Fix rubocop issues
 
 ## v0.0.9 (2016-09-16)
 - **[PR #24](https://github.com/shortdudey123/yamllint/pull/24)** - Update RSpec raise_error to be more specific

--- a/Rakefile
+++ b/Rakefile
@@ -12,52 +12,52 @@ end
 
 desc 'rubocop compliancy checks'
 RuboCop::RakeTask.new(:rubocop) do |t|
-  t.patterns = %w( lib/**/*.rb lib/*.rb spec/*.rb )
+  t.patterns = %w[lib/**/*.rb lib/*.rb spec/*.rb]
 end
 
 desc 'yamllint rake test'
 YamlLint::RakeTask.new do |t|
-  t.paths = %w( spec/data/valid* )
+  t.paths = %w[spec/data/valid*]
 end
 
 desc 'yamllint rake test with exclude_paths'
 YamlLint::RakeTask.new(:yamllint_exclude_paths) do |t|
-  t.paths = %w(
+  t.paths = %w[
     spec/data/*
-  )
-  t.exclude_paths = %w(
+  ]
+  t.exclude_paths = %w[
     spec/data/custom_extension.eyaml
     spec/data/invalid.yaml
     spec/data/overlapping_keys.yaml
     spec/data/overlapping_keys_deep.yaml
     spec/data/wrong_extension.txt
-  )
+  ]
 end
 
 desc 'yamllint rake test disabled file ext check'
 YamlLint::RakeTask.new(:yamllint_disable_ext_check) do |t|
-  t.paths = %w( spec/data/wrong_extension.txt )
+  t.paths = %w[spec/data/wrong_extension.txt]
   t.disable_ext_check = true
 end
 
 desc 'yamllint rake test disabled file ext check'
 YamlLint::RakeTask.new(:yamllint_custom_ext) do |t|
-  t.paths = %w( spec/data/custom_extension.eyaml )
-  t.extensions = %w( eyaml )
+  t.paths = %w[spec/data/custom_extension.eyaml]
+  t.extensions = %w[eyaml]
 end
 
 desc 'yamllint rake test disabled file ext check'
 YamlLint::RakeTask.new(:yamllint_debug_logging) do |t|
-  t.paths = %w( spec/data/valid.yaml )
+  t.paths = %w[spec/data/valid.yaml]
   t.debug = true
 end
 
-task default: [
-  :rubocop,
-  :yamllint,
-  :yamllint_exclude_paths,
-  :yamllint_disable_ext_check,
-  :yamllint_custom_ext,
-  :yamllint_debug_logging,
-  :spec
+task default: %i[
+  rubocop
+  yamllint
+  yamllint_exclude_paths
+  yamllint_disable_ext_check
+  yamllint_custom_ext
+  yamllint_debug_logging
+  spec
 ]

--- a/bin/yamllint
+++ b/bin/yamllint
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH << File.expand_path('../../lib', __FILE__)
+$LOAD_PATH << File.expand_path('../lib', __dir__)
 
 require 'yamllint'
 require 'yamllint/cli'

--- a/lib/yamllint.rb
+++ b/lib/yamllint.rb
@@ -8,7 +8,7 @@ require 'yamllint/linter'
 # YamlLint checks YAML files for correct syntax
 module YamlLint
   def self.logger
-    @logger ||= Logger.new(STDOUT).tap do |l|
+    @logger ||= Logger.new($stdout).tap do |l|
       l.level = Logger::INFO
     end
   end

--- a/lib/yamllint.rb
+++ b/lib/yamllint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 require 'yamllint/version'

--- a/lib/yamllint/cli.rb
+++ b/lib/yamllint/cli.rb
@@ -9,7 +9,7 @@ module YamlLint
     attr_reader :opts
 
     # setup CLI options
-    def initialize(argv, stdin = STDIN, stdout = STDOUT, stderr = STDERR,
+    def initialize(argv, stdin = $stdin, stdout = $stdout, stderr = $stderr,
                    kernel = Kernel)
       @argv = argv
       @stdin = stdin
@@ -67,7 +67,7 @@ module YamlLint
     def lint_stream
       linter = YamlLint::Linter.new
       begin
-        linter.check_stream(STDIN)
+        linter.check_stream($stdin)
       rescue StandardError => e
         @stderr.puts e.message
         exit(1)

--- a/lib/yamllint/cli.rb
+++ b/lib/yamllint/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'optimist'
 

--- a/lib/yamllint/cli.rb
+++ b/lib/yamllint/cli.rb
@@ -41,6 +41,7 @@ module YamlLint
 
       puts 'YamlLint found no errors' unless linter.errors?
       return unless linter.errors?
+
       linter.display_errors
       puts "YAML lint found #{linter.errors_count} errors"
       @kernel.exit(1)
@@ -55,7 +56,7 @@ module YamlLint
       begin
         puts "Checking #{files_to_check.flatten.length} files"
         linter.check_all(files_to_check)
-      rescue => e
+      rescue StandardError => e
         @stderr.puts e.message
         exit(1)
       end
@@ -67,7 +68,7 @@ module YamlLint
       linter = YamlLint::Linter.new
       begin
         linter.check_stream(STDIN)
-      rescue => e
+      rescue StandardError => e
         @stderr.puts e.message
         exit(1)
       end

--- a/lib/yamllint/errors.rb
+++ b/lib/yamllint/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YamlLint
   class FileNotFoundError < StandardError; end
 end

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 require 'yaml'
 

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -8,10 +8,7 @@ module YamlLint
   # Runs the actual linting
   #
   class Linter
-    attr_reader :disable_extension_check
-    attr_reader :errors
-    attr_reader :extensions
-    attr_reader :valid_extensions
+    attr_reader :disable_extension_check, :errors, :extensions, :valid_extensions
 
     # Initilize the linter
     # Params:
@@ -36,11 +33,9 @@ module YamlLint
       raise FileNotFoundError, "#{path}: no such file" unless File.exist?(path)
 
       valid = false
-      unless disable_extension_check
-        unless check_filename(path)
-          errors[path] = ['File extension must be .yaml or .yml']
-          return valid
-        end
+      if !disable_extension_check && !check_filename(path)
+        errors[path] = ['File extension must be .yaml or .yml']
+        return valid
       end
 
       File.open(path, 'r') do |f|
@@ -89,6 +84,7 @@ module YamlLint
     def check_filename(filename)
       extension = filename.split('.').last
       return true if valid_extensions.include?(extension)
+
       false
     end
 
@@ -234,6 +230,7 @@ module YamlLint
         YamlLint.logger.debug { "Checking #{full_key.join('.')} for overlap" }
 
         return if @seen_keys.add?(full_key)
+
         YamlLint.logger.debug { "Overlapping key #{full_key.join('.')}" }
         @overlapping_keys << full_key
       end

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -108,7 +108,7 @@ module YamlLint
       end
       # rubocop:enable Security/YAMLLoad
       true
-    rescue YAML::SyntaxError, Psych::Exception => e
+    rescue Psych::Exception => e
       errors_array << e.message
       false
     end

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -140,7 +140,7 @@ module YamlLint
       private
 
       # Recusively check for duplicate keys
-      def parse_recurse(psych_parse_data, is_sequence = false)
+      def parse_recurse(psych_parse_data, is_sequence = false) # rubocop:disable Style/OptionalBooleanParameter
         return if psych_parse_data.nil?
 
         is_key = false

--- a/lib/yamllint/rake_task.rb
+++ b/lib/yamllint/rake_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 require 'rake/tasklib'
 

--- a/lib/yamllint/rake_task.rb
+++ b/lib/yamllint/rake_task.rb
@@ -8,13 +8,7 @@ module YamlLint
   # RakeTast execution
   #
   class RakeTask < Rake::TaskLib
-    attr_accessor :name
-    attr_accessor :debug
-    attr_accessor :disable_ext_check
-    attr_accessor :exclude_paths
-    attr_accessor :extensions
-    attr_accessor :fail_on_error
-    attr_accessor :paths
+    attr_accessor :name, :debug, :disable_ext_check, :exclude_paths, :extensions, :fail_on_error, :paths
 
     def initialize(name = :yamllint)
       @debug = false

--- a/lib/yamllint/rake_task.rb
+++ b/lib/yamllint/rake_task.rb
@@ -13,6 +13,8 @@ module YamlLint
     attr_accessor :name, :debug, :disable_ext_check, :exclude_paths, :extensions, :fail_on_error, :paths
 
     def initialize(name = :yamllint)
+      super()
+
       @debug = false
       @disable_ext_check = false
       @exclude_paths = []

--- a/lib/yamllint/version.rb
+++ b/lib/yamllint/version.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 ###
 #
 # YamlLint checks YAML files for correct syntax
 module YamlLint
-  VERSION = '0.0.9'.freeze
+  VERSION = '0.0.9'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ module CliSpecHelpers
   end
 
   def yamllint_bin
-    File.expand_path('../../bin/yamllint', __FILE__)
+    File.expand_path('../bin/yamllint', __dir__)
   end
 end
 

--- a/yamllint.gemspec
+++ b/yamllint.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.homepage      = ''
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})

--- a/yamllint.gemspec
+++ b/yamllint.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'yamllint/version'
 
@@ -20,11 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'optimist'
 
+  spec.add_development_dependency 'aruba', '~> 0.12'
   spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'aruba', '~> 0.12'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'coveralls'
 end


### PR DESCRIPTION
I'm proposing this as an alternative to #39, basically just because #39 is several years old. (Changes to both this gem and rubocop cops make it easier to redo that work, in my opinion.)

This PR now passes `bundle exec rake`, both its rubocop check and its test suite. It's noisy but it passes. 🎉 

I don't think any of these changes are unusual. I'm happy to discuss/defend my choices. I don't have strongly held opinions about any of this.

One change is fixing my own mistake with rescuing both an exception class and one of its subclasses (oops).

I would suggest switching CI from Travis to GitHub Actions as a more modern approach, and when doing that pick a range of ruby releases that fits with whatever `required_ruby_version` you pick. I picked `>= 2.4` pretty arbitrarily. That version's been EOL for [2 years](https://endoflife.date/ruby) and supporting earlier versions is probably not necessary at this point.

For the first commit, I just ran `rubocop --auto-correct` and skimmed the resulting diff. Generally I trust rubocop's autocorrections when they are listed as safe. The remaining commits were all inspected carefully or hand-written.

This all ran with rubocop 1.29.0 except I think the first auto-correct ran with 1.26.0.